### PR TITLE
Implement simple tarot reading site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Amnesia
+
+Simple static site that lets you draw a three-card tarot reading using public Rider-Waite images.
+
+## Usage
+
+Open `index.html` in a browser or start a local server:
+
+```bash
+npm start
+```
+
+## Testing
+
+```bash
+npm test
+```

--- a/cards.json
+++ b/cards.json
@@ -1,0 +1,147 @@
+[
+  {
+    "name": "Дурень",
+    "image": "https://upload.wikimedia.org/wikipedia/commons/5/53/RWS_Tarot_00_Fool.jpg",
+    "meaning": "Новий початок, свобода"
+  },
+  {
+    "name": "Маг",
+    "image": "https://upload.wikimedia.org/wikipedia/commons/4/4d/RWS_Tarot_01_Magician.jpg",
+    "meaning": "Воля, прояв задумів"
+  },
+  {
+    "name": "Жриця",
+    "image": "https://upload.wikimedia.org/wikipedia/commons/8/88/RWS_Tarot_02_High_Priestess.jpg",
+    "meaning": "Інтуїція, внутрішнє знання"
+  },
+  {
+    "name": "Імператриця",
+    "image": "https://upload.wikimedia.org/wikipedia/commons/d/d2/RWS_Tarot_03_Empress.jpg",
+    "meaning": "Плідність, творчість"
+  },
+  {
+    "name": "Імператор",
+    "image": "https://upload.wikimedia.org/wikipedia/commons/c/c3/RWS_Tarot_04_Emperor.jpg",
+    "meaning": "Структура, авторитет"
+  },
+  {
+    "name": "Ієрофант",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_05_Hierophant.jpg",
+    "meaning": "Традиції, духовний наставник"
+  },
+  {
+    "name": "Закохані",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_06_Lovers.jpg",
+    "meaning": "Вибір, партнерство"
+  },
+  {
+    "name": "Колісниця",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_07_Chariot.jpg",
+    "meaning": "Перемога, рішучість"
+  },
+  {
+    "name": "Сила",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_08_Strength.jpg",
+    "meaning": "Внутрішня міць, сміливість"
+  },
+  {
+    "name": "Відлюдник",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_09_Hermit.jpg",
+    "meaning": "Самотність, пошук мудрості"
+  },
+  {
+    "name": "Колесо Фортуни",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_10_Wheel_of_Fortune.jpg",
+    "meaning": "Цикли, змінність"
+  },
+  {
+    "name": "Справедливість",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_11_Justice.jpg",
+    "meaning": "Баланс, закон"
+  },
+  {
+    "name": "Повішений",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_12_Hanged_Man.jpg",
+    "meaning": "Пауза, новий погляд"
+  },
+  {
+    "name": "Смерть",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_13_Death.jpg",
+    "meaning": "Кінець, трансформація"
+  },
+  {
+    "name": "Помірність",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_14_Temperance.jpg",
+    "meaning": "Гармонія, терпіння"
+  },
+  {
+    "name": "Диявол",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_15_Devil.jpg",
+    "meaning": "Спокуса, прив'язаність"
+  },
+  {
+    "name": "Вежа",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_16_Tower.jpg",
+    "meaning": "Руйнування, прозріння"
+  },
+  {
+    "name": "Зірка",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_17_Star.jpg",
+    "meaning": "Надія, натхнення"
+  },
+  {
+    "name": "Місяць",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_18_Moon.jpg",
+    "meaning": "Ілюзії, підсвідомість"
+  },
+  {
+    "name": "Сонце",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_19_Sun.jpg",
+    "meaning": "Ясність, успіх"
+  },
+  {
+    "name": "Суд",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_20_Judgement.jpg",
+    "meaning": "Пробудження, оцінка"
+  },
+  {
+    "name": "Світ",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/RWS_Tarot_21_World.jpg",
+    "meaning": "Завершення, цілісність"
+  },
+  {
+    "name": "Туз Кубків",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/Cups01.jpg",
+    "meaning": "Емоційний початок"
+  },
+  {
+    "name": "Двійка Кубків",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/Cups02.jpg",
+    "meaning": "Партнерство, союз"
+  },
+  {
+    "name": "Трійка Кубків",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/Cups03.jpg",
+    "meaning": "Святкування, спільнота"
+  },
+  {
+    "name": "Четвірка Кубків",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/Cups04.jpg",
+    "meaning": "Апатія, переоцінка"
+  },
+  {
+    "name": "П'ятірка Кубків",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/Cups05.jpg",
+    "meaning": "Втрати, жалоба"
+  },
+  {
+    "name": "Шістка Кубків",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/Cups06.jpg",
+    "meaning": "Спогади, ностальгія"
+  },
+  {
+    "name": "Сімка Кубків",
+    "image": "https://en.wikipedia.org/wiki/Special:FilePath/Cups07.jpg",
+    "meaning": "Фантазії, варіанти"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="UTF-8" />
+  <title>Розклад Таро</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;600&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main>
+    <h1>Розклад Таро</h1>
+    <button id="draw">Зробити розклад</button>
+    <div id="cards" class="cards"></div>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "amnesia-tarot",
+  "version": "1.0.0",
+  "description": "Simple tarot reading site using public card images",
+  "scripts": {
+    "start": "npx serve .",
+    "test": "echo 'No tests specified'"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,33 @@
+async function loadCards() {
+  const response = await fetch('cards.json');
+  return response.json();
+}
+
+function draw(cards, count = 3) {
+  const deck = [...cards];
+  deck.sort(() => Math.random() - 0.5);
+  return deck.slice(0, count);
+}
+
+function render(selection) {
+  const container = document.getElementById('cards');
+  container.innerHTML = '';
+  selection.forEach(card => {
+    const div = document.createElement('div');
+    div.className = 'card';
+    const img = document.createElement('img');
+    img.src = card.image;
+    img.alt = card.name;
+    const title = document.createElement('p');
+    title.textContent = card.name;
+    div.appendChild(img);
+    div.appendChild(title);
+    container.appendChild(div);
+  });
+}
+
+document.getElementById('draw').addEventListener('click', async () => {
+  const cards = await loadCards();
+  const selection = draw(cards);
+  render(selection);
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,56 @@
+body {
+  margin: 0;
+  font-family: 'Montserrat', sans-serif;
+  color: #e0e0e0;
+  background: linear-gradient(to bottom, #1e1e2c, #4b2c83);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+main {
+  text-align: center;
+}
+
+h1 {
+  font-family: 'Playfair Display', serif;
+  margin-bottom: 1rem;
+}
+
+button {
+  background-color: #00bfa6;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+button:hover {
+  background-color: #009c86;
+}
+
+.cards {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.card {
+  width: 150px;
+}
+
+.card img {
+  width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+.card p {
+  margin-top: 0.5rem;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- add static tarot reading page with Rider-Waite card images
- style page with dark gradient and mystic theme
- provide card data and basic script to draw three random cards
- expand deck with 24 additional cards from major arcana and cups suit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5bd529c808324af61ed0600d26705